### PR TITLE
Performans improvoment

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,7 +11,9 @@ parameters:
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
+    ignoreErrors:
+        - identifier: missingType.iterableValue
+
 #    ignoreErrors:
 #        - '#.*Internal error.*#'
     excludePaths:

--- a/src/AAuth.php
+++ b/src/AAuth.php
@@ -211,6 +211,7 @@ class AAuth
     {
         $rootNodes = OrganizationNode::whereIn('id', $this->organizationNodeIds)->get();
         throw_unless($rootNodes->isNotEmpty(), new InvalidOrganizationNodeException());
+
         return OrganizationNode::where(function ($query) use ($rootNodes, $includeRootNode) {
             foreach ($rootNodes as $rootNode) {
                 $query->orWhere('path', 'like', $rootNode->path . '/%');

--- a/src/Facades/AAuth.php
+++ b/src/Facades/AAuth.php
@@ -2,6 +2,7 @@
 
 namespace AuroraWebSoftware\AAuth\Facades;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Facade;
 
 /**
@@ -23,6 +24,7 @@ use Illuminate\Support\Facades\Facade;
  *
  * @method static currentRole() \AuroraWebSoftware\AAuth\Models\Role|null
  * @method static ABACRules(string $modelType) array|null
+ * @method static organizationNodesQuery(bool $includeRootNode = false, ?string $modelType = null): OrganizationNode|Builder
  */
 class AAuth extends Facade
 {

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -3,7 +3,6 @@
 namespace AuroraWebSoftware\AAuth\Models;
 
 use AuroraWebSoftware\AAuth\Contracts\AAuthUserContract;
-
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;

--- a/src/Scopes/AAuthABACModelScope.php
+++ b/src/Scopes/AAuthABACModelScope.php
@@ -98,8 +98,10 @@ class AAuthABACModelScope implements Scope
 
         $queryMethod = $parentOperator == '||' ? 'orWhere' : 'where';
 
+        $from = sprintf('%s.', is_string($builder->getQuery()->from) ? $builder->getQuery()->from : '');
+
         $builder->{$queryMethod}(
-            $rule[$operator]['attribute'],
+            $from.$rule[$operator]['attribute'],
             $operator,
             $rule[$operator]['value']
         );

--- a/src/Scopes/AAuthOrganizationNodeScope.php
+++ b/src/Scopes/AAuthOrganizationNodeScope.php
@@ -9,13 +9,60 @@ use Illuminate\Database\Eloquent\Model;
 class AAuthOrganizationNodeScope implements \Illuminate\Database\Eloquent\Scope
 {
     /**
-     * @param  Builder  $builder
-     * @param  Model  $model
+     * @param Builder<Model> $builder
+     * @param Model $model
      * @return void
      */
     public function apply(Builder $builder, Model $model): void
     {
-        $organizationNodeModelIds = AAuth::organizationNodes(true, $model::getModelType())->pluck('model_id');
-        $builder->whereIn('id', $organizationNodeModelIds);
+        $organizationNodesQuery = AAuth::organizationNodesQuery(true, $model::getModelType());
+        $query = $builder->getQuery();
+        $from = $this->getFromTableName($query->from);
+        $query->wheres = array_map(function ($where) use ($from) {
+            return $this->prefixWhereColumn($where, $from);
+        }, $query->wheres);
+
+        $builder->join('organization_nodes', 'organization_nodes.model_id', '=', sprintf('%s.id', $from))
+            ->select($this->getSelectColumns($from));
+
+        $builder->mergeWheres($organizationNodesQuery->getQuery()->wheres, $organizationNodesQuery->getBindings());
+    }
+
+    /**
+     * Get the table name from the query's "from" clause
+     *
+     * @param mixed $from
+     * @return string
+     */
+    protected function getFromTableName(mixed $from): string
+    {
+        return is_string($from) ? $from : '';
+    }
+
+    /**
+     * Prefix the where column with the table name if needed
+     *
+     * @param array $where
+     * @param string $from
+     * @return array
+     */
+    protected function prefixWhereColumn(array $where, string $from): array
+    {
+        if (isset($where['column']) && ! str_contains($where['column'], $from . '.')) {
+            $where['column'] = sprintf('%s.%s', $from, $where['column']);
+        }
+
+        return $where;
+    }
+
+    /**
+     * Get the select columns for the query (only selects fields from the left table)
+     *
+     * @param string $from
+     * @return array
+     */
+    protected function getSelectColumns(string $from): array
+    {
+        return ["{$from}.*"];
     }
 }


### PR DESCRIPTION
Optimized Organization Node Queries for Performance Improvement
Summary: This PR introduces optimizations in the organization node queries by replacing WHERE IN clauses with direct JOINs. The goal is to enhance query performance, particularly when dealing with large datasets.

Key Changes:

Replaced WHERE IN conditions with JOIN operations to fetch related organization nodes more efficiently.
Reduced the overhead of executing multiple queries and simplified the data retrieval process.
This change will help improve scalability and performance, especially in scenarios with many organization nodes.
Why this change? Using JOINs instead of WHERE IN allows for more efficient querying by reducing the number of queries and eliminating the need to fetch and process large sets of IDs separately. This optimization should improve overall system performance.

Impact:

Faster query execution times.
Better performance when handling larger datasets.
Potential reduction in memory usage due to fewer queries and data loads.