### PR TITLE
feat: Add Devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+# Use the official PHP image as a base
+FROM mcr.microsoft.com/devcontainers/php:1-8.2-bullseye
+
+# Install system dependencies
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends default-mysql-client
+
+# Install PHP extensions
+RUN docker-php-ext-install pdo_mysql mbstring xml tokenizer ctype json curl dom fileinfo session bcmath
+
+# Set working directory
+WORKDIR /workspaces/${localWorkspaceFolderBasename}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+	"name": "PHP & MariaDB",
+	"dockerComposeFile": [
+		"../docker-compose.yml"
+	],
+	"service": "app",
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+	"features": {
+		"ghcr.io/devcontainers/features/php:1": {
+			"version": "8.2",
+			"installComposer": true,
+			"composerVersion": "latest"
+		}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"bmewburn.vscode-intelephense-client",
+				"xdebug.php-debug",
+				"ms-azuretools.vscode-docker",
+				"EditorConfig.EditorConfig",
+				"streetsidesoftware.code-spell-checker"
+			]
+		}
+	},
+	"postCreateCommand": "composer install && cp .env.example .env && php artisan key:generate",
+	"remoteUser": "vscode"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,37 @@
+version: '3.8'
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ..:/workspaces/${localWorkspaceFolderBasename}:cached
+    command: sleep infinity
+    depends_on:
+      - mariadb
+    networks:
+      - default
+
+  mariadb:
+    image: mariadb:10.8
+    ports:
+      - "33062:3306"
+    volumes:
+      - aurora_aauth_mariadb_data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=aauth
+      - MYSQL_PASSWORD=aauth
+      - MYSQL_USER=aauth
+      - MYSQL_DATABASE=aauth
+    networks:
+      - default
+
+volumes:
+  aurora_aauth_mariadb_data:
+
+networks:
+  default:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.16.58.0/24 # Changed subnet to avoid conflict with existing one

--- a/README.md
+++ b/README.md
@@ -532,3 +532,23 @@ Please review [our security policy](../../security/policy) on how to report secu
 ## License
 
 The MIT License (MIT). Please see [License File](LICENSE.md) for more information.
+
+## Development Environment using Dev Containers
+
+This project includes a [Dev Container](https://containers.dev/) configuration, which allows you to use a Docker container as a fully-featured development environment.
+
+### Prerequisites
+
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) installed and running.
+- [Visual Studio Code](https://code.visualstudio.com/) installed.
+- [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) for VS Code installed.
+
+### Getting Started
+
+1.  Clone this repository to your local machine.
+2.  Open the cloned repository in Visual Studio Code.
+3.  When prompted with "Reopen in Container", click the button. (If you don't see the prompt, open the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P`) and run "Dev Containers: Reopen in Container".)
+
+This will build the dev container and install all necessary dependencies. You can then develop and run the application from within this isolated environment.
+
+[![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/AuroraWebSoftware/AAuth)


### PR DESCRIPTION
This commit introduces a development container setup for the project. It includes:
- A `.devcontainer/devcontainer.json` file to define the container environment, PHP version, extensions, and post-creation commands.
- A `.devcontainer/docker-compose.yml` file to manage the application and MariaDB services.
- A `.devcontainer/Dockerfile` to specify the PHP base image and required extensions.

Additionally, the README.md has been updated with instructions on how to use the Devcontainer and an "Open in Dev Containers" badge.

This setup allows developers to quickly get started with a consistent and isolated development environment.