### PR TITLE
fix: Correct Devcontainer configuration for Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
 	"name": "PHP & MariaDB",
 	"dockerComposeFile": [
-		"../docker-compose.yml"
+		"docker-compose.yml"
 	],
 	"service": "app",
 	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   app:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,10 @@
-version: '3.7'
-
 services:
   mariadb:
     image: mariadb:10.8
     ports:
       - "33062:3306"
     volumes:
-      - ~/apps/mariadb:/var/lib/mysql
+      - aurora_aauth_root_mariadb_data:/var/lib/mysql
     environment:
       - MYSQL_ROOT_PASSWORD=aauth
       - MYSQL_PASSWORD=aauth
@@ -18,3 +16,6 @@ networks:
     ipam:
       config:
         - subnet: 172.16.57.0/24
+
+volumes:
+  aurora_aauth_root_mariadb_data:


### PR DESCRIPTION
This commit addresses issues encountered when building the devcontainer in GitHub Codespaces:

- Modified `.devcontainer/devcontainer.json` to point to the `docker-compose.yml` file located within the `.devcontainer` directory instead of the root one. This ensures the correct 'app' service definition is used.
- Removed the obsolete `version` attribute from both `.devcontainer/docker-compose.yml` and the root `docker-compose.yml` as it's no longer required by modern Docker Compose and was causing warnings.
- Updated the MariaDB service in the root `docker-compose.yml` to use a named volume (`aurora_aauth_root_mariadb_data`) instead of a host-relative path (`~/apps/mariadb`), which resolves `HOME` environment warnings and improves portability.