### PR TITLE
fix: Add libonig-dev to Dockerfile for mbstring

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/devcontainers/php:1-8.2-bullseye
 
 # Install system dependencies
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends default-mysql-client
+    && apt-get -y install --no-install-recommends default-mysql-client libonig-dev
 
 # Install PHP extensions
 RUN docker-php-ext-install pdo_mysql mbstring xml tokenizer ctype json curl dom fileinfo session bcmath


### PR DESCRIPTION
The devcontainer build was failing because the PHP extension `mbstring` requires the `oniguruma` library. This commit adds `libonig-dev` to the `apt-get install` command in the `.devcontainer/Dockerfile` to satisfy this dependency.