### PR TITLE
fix: Add php8.2-dev and php-pear to Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/devcontainers/php:1-8.2-bullseye
 
 # Install system dependencies
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends default-mysql-client libonig-dev libxml2-dev
+    && apt-get -y install --no-install-recommends default-mysql-client libonig-dev libxml2-dev php8.2-dev php-pear
 
 # Install PHP extensions
 RUN docker-php-ext-install pdo_mysql mbstring xml tokenizer ctype json curl dom fileinfo session bcmath


### PR DESCRIPTION
The devcontainer build was failing during the compilation of the `tokenizer` PHP extension, possibly due to missing PHP development headers or build tools.

This commit adds `php8.2-dev` (to match the PHP version) and `php-pear` to the `apt-get install` command in the `.devcontainer/Dockerfile`. These packages should provide the necessary components for building PHP extensions.