### PR TITLE
fix: restore PHP 8.2 support, exclude incompatible L13+8.2 cell from …

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - '**.php'
       - 'phpstan.neon.dist'
+      - 'composer.json'
+      - 'composer.lock'
+      - '.github/workflows/phpstan.yml'
+  workflow_dispatch:
 
 jobs:
   phpstan:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,9 +13,15 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.3, 8.4]
+        php: [8.2, 8.3, 8.4]
         laravel: [11.*, 12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
+        exclude:
+          # Laravel 13 requires PHP 8.3+ (via orchestra/testbench 11,
+          # phpunit 12, pest 4). Excluding the incompatible cell keeps
+          # PHP 8.2 supported for L11/L12 consumers.
+          - php: 8.2
+            laravel: 13.*
         include:
           - laravel: 11.*
             testbench: 9.*

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.3|^8.4",
+        "php": "^8.2|^8.3|^8.4",
         "laravel/pint": "^1.13",
         "spatie/laravel-package-tools": "^1.16.0",
         "laravel/framework": "^11.0|^12.0|^13.0"


### PR DESCRIPTION
…matrix

The previous commit dropped PHP 8.2 from the composer constraint, which broke .github/workflows/phpstan.yml (it pins setup-php to '8.2' and therefore failed during composer install with "Root composer.json requires php ^8.3|^8.4").

Restore PHP 8.2 in composer.json and add it back to the run-tests matrix. The L13 cell on PHP 8.2 is excluded because the Laravel-13 toolchain (orchestra/testbench 11, phpunit 12, pest 4) requires PHP 8.3+; composer's OR constraints (`^11.0|^12.0|^13.0` for Laravel, `^9.0|^10.0|^11.0` for Testbench, `^11.0|^12.0` for PHPUnit, `^3.0|^4.0` for Pest) let composer pick the right minor on each PHP version automatically.

Resulting CI matrix (3 PHP × 3 Laravel × 2 stability) − 2 excluded (PHP 8.2 + L13 in both stabilities) = 16 jobs.

Local verification (PHP 8.4 + L13 install):
- vendor/bin/pest --no-coverage  →  137 passed (274 assertions), 48s
- vendor/bin/phpstan analyse     →  0 errors